### PR TITLE
Update to Rust 1.38

### DIFF
--- a/src/atcoder-env/index.md
+++ b/src/atcoder-env/index.md
@@ -10,7 +10,7 @@
 
 ## Rustツールチェインやクレートの内容など
 
-- Rust 1.36.0
+- Rust 1.38.0
 - インストールするクレート：[このページ][crates-2019]を参照
 
 [crates-2019]: https://github.com/rust-lang-ja/atcoder-rust-resources/wiki/Crates-2019

--- a/src/atcoder-env/installing-rust-toolchain.md
+++ b/src/atcoder-env/installing-rust-toolchain.md
@@ -7,10 +7,9 @@
 
 ## Rustバージョン
 
-今回の言語アップデートでは2019年7月4日にリリースされた1.36.0をインストールします。
+今回の言語アップデートでは2019年9月26日にリリースされた1.38.0をインストールします。
 
-Rustの安定版（stable版）は6週間ごとにリリースされますので、既に次のバージョンの1.37.0が8月15日にリリースされています。
-しかし今回は安全のために、リリースされてから日が経っている1.36.0を選択します。
+Rustの安定版（stable版）は6週間ごとにリリースされますので、次のバージョン1.39.0は11月7日にリリースされる予定です。ただ、安定性のためには世に出てからある程度の時間が経っているバージョンを選ぶ方が望ましいでしょう。もし言語アップデートの作業終了間際に1.39.0がリリースされたとしても、直後に即採用することは見送った方がよいと思われます。逆に言語アップデートの時期が11月下旬～12月頃になるようでしたら1.39は有力な選択肢です。
 
 ツールチェインのインストールには`rustup`というRustプロジェクト公式のコマンドラインツールを使います。
 これにより特定のバージョンのRustをインストールすることが可能になります。
@@ -59,7 +58,7 @@ $ sudo -i
 # whoami
 root
 
-# RUST_TOOLCHAIN=1.36.0
+# RUST_TOOLCHAIN=1.38.0
 # export RUST_HOME=/usr/local/lib/rust
 # export RUSTUP_HOME=${RUST_HOME}/rustup
 # export CARGO_HOME=${RUST_HOME}/cargo
@@ -76,13 +75,14 @@ root
 
 ```console
 info: downloading installer
-info: syncing channel updates for '1.36.0-x86_64-unknown-linux-gnu'
-info: latest update on 2019-07-04, rust version 1.36.0 (a53f9df32 2019-07-03)
+info: syncing channel updates for '1.38.0-x86_64-unknown-linux-gnu'
+info: latest update on 2019-09-26, rust version 1.38.0 (625451e37 2019-09-23)
 info: downloading component 'rustc'
- 88.4 MiB /  88.4 MiB (100 %)  10.9 MiB/s in 10s ETA:  0s
+info: downloading component 'rust-std'
+info: downloading component 'cargo'
 ...（中略）...
 
-   1.36.0 installed - rustc 1.36.0 (a53f9df32 2019-07-03)
+  1.38.0 installed - rustc 1.38.0 (625451e37 2019-09-23)
 
 
 Rust is installed now. Great!
@@ -129,19 +129,19 @@ $ which rustc
 
 ## バージョンなどを確認
 $ rustc -V
-rustc 1.36.0 (a53f9df32 2019-07-03)
+rustc 1.38.0 (625451e37 2019-09-23)
 
 $ cargo -V
-cargo 1.36.0 (c4fcfb725 2019-05-15)
+cargo 1.38.0 (23ef9a4ef 2019-08-20)
 
 $ rustup -V
-rustup 1.18.3 (435397f48 2019-05-22)
+rustup 1.19.0 (2af131cf9 2019-09-08)
 
 $ rustup show
 Default host: x86_64-unknown-linux-gnu
 
-1.36.0-x86_64-unknown-linux-gnu (default)
-rustc 1.36.0 (a53f9df32 2019-07-03)
+1.38.0-x86_64-unknown-linux-gnu (default)
+rustc 1.38.0 (625451e37 2019-09-23)
 
 ## Rustプログラムのビルドと実行ができることを確認
 $ cd /tmp


### PR DESCRIPTION
I know Rust 1.38 is a bit young for now, but update would still take a
while to complete...