### PR TITLE
mdBook 0.4.5へアップグレード

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,16 @@ version: 2
 jobs:
   build:
     docker:
-      - image: quay.io/rust-lang-ja/circleci:atcoder-resources
+      - image: quay.io/rust-lang-ja/circleci:mdbook-0.4.5-rust-1.49.0
     parallelism: 1
     steps:
       - checkout
       # Remove .gitconfig added by Circle CI as cargo doesn't support ssh authorization
       - run: rm -f ~/.gitconfig
-      - run: mdbook build
+      - run: rm -rf docs
+      - run: mdbook -V
       - run: mdbook test
+      - run: mdbook build
       - store_artifacts:
           path: docs
       - deploy:


### PR DESCRIPTION
サイトの生成に使用しているmdBookのバージョンを0.3.7から0.4.5へアップデートします。理由は、0.4.5より前のバージョンで生成したサイトの検索機能にセキュリティーの脆弱性があるためです。

脆弱性の詳細：
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26297
- https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html

なお、mdBook 0.4.0〜0.4.5には `SUMMARY.md` 内にHTMLコメントがあるとサイトのビルドに失敗するという問題があります。そのため、当方にて修正したバージョンを使っています（mdBookのupstreamへ [pull request #1437](https://github.com/rust-lang/mdBook/pull/1437) を提出済み）